### PR TITLE
Fix a typo in the s file

### DIFF
--- a/s
+++ b/s
@@ -2,7 +2,7 @@
 
 /** eslint-disable */
 /**
- * A script to make git comit messages more readable
+ * A script to make git commit messages more readable
  * on terminal by replacing emojis with simple words.
  * @example
  *     ./s log -5 --oneline


### PR DESCRIPTION
I fixed a typo in the s file:
`git comit` -> `git commit`